### PR TITLE
style: Extract UI constants and refactor main view rendering

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+# golangci-lint configuration
+# https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+    - gocritic
+    - gofmt
+
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment
+  gosec:
+    excludes:
+      - G304 # File path provided as taint input - handled with #nosec comments where needed
+  gocritic:
+    disabled-checks:
+      - ifElseChain # Complex conditionals are clearer as if-else than switch true

--- a/internal/benchmark/results.go
+++ b/internal/benchmark/results.go
@@ -1,3 +1,14 @@
+// Package benchmark provides HTTP benchmarking capabilities for port forwards.
+// It measures latency, throughput, and reliability of forwarded connections.
+//
+// The benchmark runner sends configurable numbers of concurrent requests
+// and collects statistics including:
+//   - Latency percentiles (P50, P95, P99)
+//   - Request success/failure rates
+//   - Throughput (requests/second)
+//   - Status code distribution
+//
+// Results can be displayed in the UI or exported for analysis.
 package benchmark
 
 import (
@@ -7,17 +18,17 @@ import (
 
 // Results holds the aggregated results of a benchmark run
 type Results struct {
-	ForwardID     string          `json:"forward_id"`
-	URL           string          `json:"url"`
-	Method        string          `json:"method"`
 	StartTime     time.Time       `json:"start_time"`
 	EndTime       time.Time       `json:"end_time"`
+	StatusCodes   map[int]int     `json:"status_codes"`
+	Errors        map[string]int  `json:"errors,omitempty"`
+	Method        string          `json:"method"`
+	URL           string          `json:"url"`
+	ForwardID     string          `json:"forward_id"`
+	Latencies     []time.Duration `json:"-"`
 	TotalRequests int             `json:"total_requests"`
 	Successful    int             `json:"successful"`
 	Failed        int             `json:"failed"`
-	Latencies     []time.Duration `json:"-"` // Raw latencies for percentile calculation
-	StatusCodes   map[int]int     `json:"status_codes"`
-	Errors        map[string]int  `json:"errors,omitempty"`
 	BytesRead     int64           `json:"bytes_read"`
 	BytesWritten  int64           `json:"bytes_written"`
 }

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -16,15 +16,15 @@ type ProgressCallback func(completed, total int)
 
 // Config holds the benchmark configuration
 type Config struct {
-	URL              string            // Target URL
-	Method           string            // HTTP method
-	Headers          map[string]string // Custom headers
-	Body             []byte            // Request body
-	Concurrency      int               // Number of concurrent workers
-	Requests         int               // Total number of requests (0 = use duration)
-	Duration         time.Duration     // Duration to run (0 = use requests)
-	Timeout          time.Duration     // Request timeout
-	ProgressCallback ProgressCallback  // Optional callback for progress updates
+	Headers          map[string]string
+	ProgressCallback ProgressCallback
+	URL              string
+	Method           string
+	Body             []byte
+	Concurrency      int
+	Requests         int
+	Duration         time.Duration
+	Timeout          time.Duration
 }
 
 // Runner executes HTTP benchmarks

--- a/internal/benchmark/runner_test.go
+++ b/internal/benchmark/runner_test.go
@@ -106,7 +106,7 @@ func TestRunner(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Millisecond) // Simulate some latency
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer server.Close()
 
@@ -132,7 +132,7 @@ func TestRunner(t *testing.T) {
 func TestRunnerWithDuration(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`ok`))
+		_, _ = w.Write([]byte(`ok`))
 	}))
 	defer server.Close()
 
@@ -210,7 +210,7 @@ func TestRunnerWithProgressCallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Millisecond) // Add small delay so progress ticker can fire
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`ok`))
+		_, _ = w.Write([]byte(`ok`))
 	}))
 	defer server.Close()
 

--- a/internal/config/config_getters_test.go
+++ b/internal/config/config_getters_test.go
@@ -40,8 +40,8 @@ func TestParseDurationOrDefault(t *testing.T) {
 // TestConfig_GetHealthCheckIntervalOrDefault tests health check interval getter
 func TestConfig_GetHealthCheckIntervalOrDefault(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -83,8 +83,8 @@ func TestConfig_GetHealthCheckIntervalOrDefault(t *testing.T) {
 // TestConfig_GetHealthCheckTimeoutOrDefault tests health check timeout getter
 func TestConfig_GetHealthCheckTimeoutOrDefault(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -162,8 +162,8 @@ func TestConfig_GetHealthCheckMethod(t *testing.T) {
 // TestConfig_GetMaxConnectionAge tests max connection age getter
 func TestConfig_GetMaxConnectionAge(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -198,8 +198,8 @@ func TestConfig_GetMaxConnectionAge(t *testing.T) {
 // TestConfig_GetMaxIdleTime tests max idle time getter
 func TestConfig_GetMaxIdleTime(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -234,8 +234,8 @@ func TestConfig_GetMaxIdleTime(t *testing.T) {
 // TestConfig_GetTCPKeepalive tests TCP keepalive getter
 func TestConfig_GetTCPKeepalive(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -270,8 +270,8 @@ func TestConfig_GetTCPKeepalive(t *testing.T) {
 // TestConfig_GetRetryOnStale tests retry on stale getter
 func TestConfig_GetRetryOnStale(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected bool
 	}{
 		{
@@ -306,8 +306,8 @@ func TestConfig_GetRetryOnStale(t *testing.T) {
 // TestConfig_GetWatchdogPeriod tests watchdog period getter
 func TestConfig_GetWatchdogPeriod(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -342,8 +342,8 @@ func TestConfig_GetWatchdogPeriod(t *testing.T) {
 // TestConfig_GetDialTimeout tests dial timeout getter
 func TestConfig_GetDialTimeout(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected time.Duration
 	}{
 		{
@@ -378,8 +378,8 @@ func TestConfig_GetDialTimeout(t *testing.T) {
 // TestConfig_IsMDNSEnabled tests mDNS enabled getter
 func TestConfig_IsMDNSEnabled(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected bool
 	}{
 		{
@@ -509,8 +509,8 @@ func TestForward_GetHTTPLogMaxBodySize(t *testing.T) {
 func TestForward_GetMDNSAlias(t *testing.T) {
 	tests := []struct {
 		name     string
-		forward  Forward
 		expected string
+		forward  Forward
 	}{
 		{
 			name: "explicit alias",
@@ -591,7 +591,7 @@ func TestLoadConfig_FileTooLarge(t *testing.T) {
 		largeData[i] = 'a'
 	}
 
-	err := os.WriteFile(configPath, largeData, 0644)
+	err := os.WriteFile(configPath, largeData, 0600)
 	require.NoError(t, err)
 
 	cfg, err := LoadConfig(configPath)
@@ -628,7 +628,7 @@ mdns:
   enabled: true
 `
 
-	err := os.WriteFile(configPath, []byte(yaml), 0644)
+	err := os.WriteFile(configPath, []byte(yaml), 0600)
 	require.NoError(t, err)
 
 	cfg, err := LoadConfig(configPath)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,7 +39,7 @@ func TestLoadConfig_ValidYAML(t *testing.T) {
             localPort: 8081
 `
 
-	err := os.WriteFile(configPath, []byte(validYAML), 0644)
+	err := os.WriteFile(configPath, []byte(validYAML), 0600)
 	assert.NoError(t, err, "should write temp config file")
 
 	// Load the config
@@ -82,7 +82,7 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
         forwards: [this is invalid yaml syntax
 `
 
-	err := os.WriteFile(configPath, []byte(invalidYAML), 0644)
+	err := os.WriteFile(configPath, []byte(invalidYAML), 0600)
 	assert.NoError(t, err, "should write temp config file")
 
 	// Load the config
@@ -103,8 +103,8 @@ func TestLoadConfig_FileNotFound(t *testing.T) {
 func TestForward_ID(t *testing.T) {
 	tests := []struct {
 		name       string
-		forward    Forward
 		expectedID string
+		forward    Forward
 	}{
 		{
 			name: "pod with explicit name",
@@ -165,8 +165,8 @@ func TestForward_ID(t *testing.T) {
 func TestForward_String(t *testing.T) {
 	tests := []struct {
 		name           string
-		forward        Forward
 		expectedString string
+		forward        Forward
 	}{
 		{
 			name: "pod without selector",
@@ -389,10 +389,8 @@ func TestHTTPLogSpec_UnmarshalYAML(t *testing.T) {
 			if tt.expected {
 				assert.NotNil(t, fwd.HTTPLog, "HTTPLog should not be nil")
 				assert.True(t, fwd.HTTPLog.Enabled, "HTTPLog.Enabled should be true")
-			} else {
-				if fwd.HTTPLog != nil {
-					assert.False(t, fwd.HTTPLog.Enabled, "HTTPLog.Enabled should be false")
-				}
+			} else if fwd.HTTPLog != nil {
+				assert.False(t, fwd.HTTPLog.Enabled, "HTTPLog.Enabled should be false")
 			}
 		})
 	}
@@ -407,8 +405,8 @@ func TestNewEmptyConfig(t *testing.T) {
 
 func TestConfig_IsEmpty(t *testing.T) {
 	tests := []struct {
-		name     string
 		config   *Config
+		name     string
 		expected bool
 	}{
 		{
@@ -505,7 +503,7 @@ func TestCreateEmptyConfigFile_AlreadyExists(t *testing.T) {
 	configPath := filepath.Join(tmpDir, ".kportal.yaml")
 
 	// Create existing file
-	err := os.WriteFile(configPath, []byte("existing content"), 0644)
+	err := os.WriteFile(configPath, []byte("existing content"), 0600)
 	assert.NoError(t, err)
 
 	// Try to create config file - should fail

--- a/internal/config/mutator_test.go
+++ b/internal/config/mutator_test.go
@@ -648,7 +648,7 @@ func TestMutator_Concurrent(t *testing.T) {
 			}
 			// Some will succeed, some will fail due to validation
 			// The important thing is no race condition
-			mutator.AddForward("dev", "default", fwd)
+			_ = mutator.AddForward("dev", "default", fwd)
 		}(i)
 	}
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -17,9 +17,9 @@ func IsValidPort(port int) bool {
 
 // ValidationError represents a configuration validation error with context.
 type ValidationError struct {
-	Field   string            // The field that failed validation
-	Message string            // Error message
-	Context map[string]string // Additional context information
+	Context map[string]string
+	Field   string
+	Message string
 }
 
 // Validator validates configuration files.
@@ -199,14 +199,12 @@ func (v *Validator) validateResource(fwd *Forward) []ValidationError {
 					Message: fmt.Sprintf("Pod name cannot be empty for forward %s", fwd.ID()),
 				})
 			}
-		} else {
+		} else if fwd.Selector == "" {
 			// pod (no name) - must have selector
-			if fwd.Selector == "" {
-				errs = append(errs, ValidationError{
-					Field:   "selector",
-					Message: fmt.Sprintf("Forward %s uses generic 'pod' resource and must have a selector", fwd.ID()),
-				})
-			}
+			errs = append(errs, ValidationError{
+				Field:   "selector",
+				Message: fmt.Sprintf("Forward %s uses generic 'pod' resource and must have a selector", fwd.ID()),
+			})
 		}
 	}
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -11,10 +11,10 @@ func TestValidator_ValidateConfig(t *testing.T) {
 	validator := NewValidator()
 
 	tests := []struct {
-		name          string
 		config        *Config
-		expectErrors  bool
+		name          string
 		errorContains []string
+		expectErrors  bool
 	}{
 		{
 			name: "valid config",
@@ -227,9 +227,9 @@ func TestValidator_ValidateResourceFormat(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		errorContains []string
 		forward       Forward
 		expectErrors  bool
-		errorContains []string
 	}{
 		{
 			name: "valid pod with name",
@@ -370,10 +370,10 @@ func TestValidator_CheckDuplicatePorts(t *testing.T) {
 	validator := NewValidator()
 
 	tests := []struct {
-		name          string
 		config        *Config
-		expectErrors  bool
+		name          string
 		errorContains []string
+		expectErrors  bool
 	}{
 		{
 			name: "no duplicate ports",
@@ -552,8 +552,8 @@ func TestFormatValidationErrors(t *testing.T) {
 	tests := []struct {
 		name           string
 		errors         []ValidationError
-		expectEmpty    bool
 		expectContains []string
+		expectEmpty    bool
 	}{
 		{
 			name:        "no errors",
@@ -625,10 +625,10 @@ func TestValidator_ValidateStructure(t *testing.T) {
 	validator := NewValidator()
 
 	tests := []struct {
-		name          string
 		config        *Config
-		expectErrors  bool
+		name          string
 		errorContains []string
+		expectErrors  bool
 	}{
 		{
 			name: "empty context name",
@@ -697,10 +697,10 @@ func TestValidator_ValidateMDNS(t *testing.T) {
 	validator := NewValidator()
 
 	tests := []struct {
-		name          string
 		config        *Config
-		expectErrors  bool
+		name          string
 		errorContains []string
+		expectErrors  bool
 	}{
 		{
 			name: "mDNS disabled - no validation",
@@ -968,8 +968,8 @@ func TestValidator_ValidateConfigWithOptions(t *testing.T) {
 	validator := NewValidator()
 
 	tests := []struct {
-		name         string
 		config       *Config
+		name         string
 		allowEmpty   bool
 		expectErrors bool
 	}{

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -27,7 +27,7 @@ func TestNewWatcher(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }
@@ -57,7 +57,7 @@ func TestNewWatcher_Verbose(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }
@@ -85,13 +85,15 @@ func TestNewWatcher_RelativePath(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	// Change to tmpDir and use relative path
-	originalDir, _ := os.Getwd()
-	defer os.Chdir(originalDir)
-	os.Chdir(tmpDir)
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }
 
@@ -119,7 +121,7 @@ func TestWatcher_StartStop(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }
@@ -161,7 +163,7 @@ func TestWatcher_DetectsFileChange(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	var mu sync.Mutex
@@ -199,7 +201,7 @@ func TestWatcher_DetectsFileChange(t *testing.T) {
             port: 9090
             localPort: 9090
 `
-	err = os.WriteFile(configPath, []byte(updated), 0644)
+	err = os.WriteFile(configPath, []byte(updated), 0600)
 	require.NoError(t, err)
 
 	// Wait for callback with timeout
@@ -239,7 +241,7 @@ func TestWatcher_IgnoresInvalidConfig(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callbackCount := 0
@@ -267,7 +269,7 @@ func TestWatcher_IgnoresInvalidConfig(t *testing.T) {
       - name: default
         forwards: [this is invalid
 `
-	err = os.WriteFile(configPath, []byte(invalid), 0644)
+	err = os.WriteFile(configPath, []byte(invalid), 0600)
 	require.NoError(t, err)
 
 	// Wait a bit
@@ -294,7 +296,7 @@ func TestWatcher_IgnoresValidationErrors(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callbackCount := 0
@@ -328,7 +330,7 @@ func TestWatcher_IgnoresValidationErrors(t *testing.T) {
             port: 9090
             localPort: 8080
 `
-	err = os.WriteFile(configPath, []byte(invalid), 0644)
+	err = os.WriteFile(configPath, []byte(invalid), 0600)
 	require.NoError(t, err)
 
 	// Wait a bit
@@ -356,7 +358,7 @@ func TestWatcher_IgnoresOtherFiles(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callbackCount := 0
@@ -378,7 +380,7 @@ func TestWatcher_IgnoresOtherFiles(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Write to a different file
-	err = os.WriteFile(otherPath, []byte("some content"), 0644)
+	err = os.WriteFile(otherPath, []byte("some content"), 0600)
 	require.NoError(t, err)
 
 	// Wait a bit
@@ -405,7 +407,7 @@ func TestWatcher_HandleReload_LoadError(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callbackCalled := false
@@ -445,7 +447,7 @@ func TestWatcher_DoubleStop(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }
@@ -479,7 +481,7 @@ func TestWatcher_StopWithoutStart(t *testing.T) {
             port: 8080
             localPort: 8080
 `
-	err := os.WriteFile(configPath, []byte(initial), 0644)
+	err := os.WriteFile(configPath, []byte(initial), 0600)
 	require.NoError(t, err)
 
 	callback := func(cfg *Config) error { return nil }

--- a/internal/converter/kftray.go
+++ b/internal/converter/kftray.go
@@ -1,3 +1,12 @@
+// Package converter provides configuration migration from other port-forwarding
+// tools to kportal's YAML format. Currently supports kftray JSON format.
+//
+// Basic usage:
+//
+//	err := converter.ConvertKFTrayToKPortal("kftray.json", ".kportal.yaml")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 package converter
 
 import (
@@ -14,12 +23,12 @@ import (
 type KFTrayConfig struct {
 	Service      string `json:"service"`
 	Namespace    string `json:"namespace"`
-	LocalPort    int    `json:"local_port"`
-	RemotePort   int    `json:"remote_port"`
 	Context      string `json:"context"`
 	WorkloadType string `json:"workload_type"`
 	Protocol     string `json:"protocol"`
 	Alias        string `json:"alias"`
+	LocalPort    int    `json:"local_port"`
+	RemotePort   int    `json:"remote_port"`
 }
 
 // ConvertKFTrayToKPortal converts kftray JSON configuration to kportal YAML format
@@ -32,8 +41,8 @@ func ConvertKFTrayToKPortal(inputFile, outputFile string) error {
 	}
 
 	var kftrayConfigs []KFTrayConfig
-	if err := json.Unmarshal(data, &kftrayConfigs); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
+	if unmarshalErr := json.Unmarshal(data, &kftrayConfigs); unmarshalErr != nil {
+		return fmt.Errorf("failed to parse JSON: %w", unmarshalErr)
 	}
 
 	// Convert to kportal format
@@ -169,9 +178,9 @@ type namespaceEntry struct {
 type forwardEntry struct {
 	Resource  string `yaml:"resource"`
 	Protocol  string `yaml:"protocol"`
+	Alias     string `yaml:"alias,omitempty"`
 	Port      int    `yaml:"port"`
 	LocalPort int    `yaml:"localPort"`
-	Alias     string `yaml:"alias,omitempty"`
 }
 
 // Convert internal types to config package types

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,3 +1,21 @@
+// Package events provides a publish-subscribe event bus for decoupled
+// communication between kportal components. Events are typed and carry
+// contextual data about forward lifecycle, health status, and configuration
+// changes.
+//
+// Event types include:
+//   - Forward lifecycle: starting, connected, disconnected, reconnecting, stopped, error
+//   - Health: status_changed, stale
+//   - Watchdog: worker_hung
+//   - Config: reloaded
+//
+// Basic usage:
+//
+//	bus := events.NewBus()
+//	bus.Subscribe(events.EventForwardConnected, func(e events.Event) {
+//	    fmt.Printf("Forward %s connected\n", e.ForwardID)
+//	})
+//	bus.Publish(events.Event{Type: events.EventForwardConnected, ForwardID: "..."})
 package events
 
 import (
@@ -29,9 +47,9 @@ const (
 
 // Event represents a system event
 type Event struct {
+	Data      map[string]interface{}
 	Type      EventType
 	ForwardID string
-	Data      map[string]interface{}
 }
 
 // Handler is a function that handles events
@@ -39,8 +57,8 @@ type Handler func(event Event)
 
 // Bus is a simple event bus for decoupled communication between components
 type Bus struct {
-	mu       sync.RWMutex
 	handlers map[EventType][]Handler
+	mu       sync.RWMutex
 	closed   bool
 }
 

--- a/internal/forward/manager_test.go
+++ b/internal/forward/manager_test.go
@@ -185,8 +185,8 @@ type StatusUpdate struct {
 }
 
 type ForwardAdd struct {
-	ID  string
 	Fwd *config.Forward
+	ID  string
 }
 
 type ErrorSet struct {

--- a/internal/forward/portcheck.go
+++ b/internal/forward/portcheck.go
@@ -99,9 +99,9 @@ func getProcessNameByPIDWindows(pid string) string {
 
 // PortConflict represents a local port that is already in use.
 type PortConflict struct {
-	Port     int    // The conflicting port number
-	Resource string // The forward resource that needs this port
-	UsedBy   string // Process information (PID, command) using the port
+	Resource string
+	UsedBy   string
+	Port     int
 }
 
 // PortChecker checks port availability on the local system.
@@ -146,7 +146,7 @@ func (pc *PortChecker) isPortAvailable(port int) bool {
 	if err != nil {
 		return false
 	}
-	_ = listener.Close()
+	_ = listener.Close() // Best-effort cleanup; port check succeeded, Close error is non-critical
 	return true
 }
 

--- a/internal/forward/portcheck_test.go
+++ b/internal/forward/portcheck_test.go
@@ -40,8 +40,8 @@ func TestIsValidPID(t *testing.T) {
 func TestFormatProcessInfo(t *testing.T) {
 	tests := []struct {
 		name     string
-		info     processInfo
 		expected string
+		info     processInfo
 	}{
 		{
 			name:     "invalid process",
@@ -72,8 +72,8 @@ func TestFormatProcessInfo(t *testing.T) {
 func TestFormatProcessList(t *testing.T) {
 	tests := []struct {
 		name      string
-		processes []processInfo
 		expected  string
+		processes []processInfo
 	}{
 		{
 			name:      "empty list",
@@ -206,7 +206,8 @@ func TestPortChecker_CheckAvailability_EmptyPorts(t *testing.T) {
 func TestPortChecker_CheckAvailability_ExcludeMap(t *testing.T) {
 	pc := NewPortChecker()
 
-	// Create a listener to occupy a port
+	// Create a listener to occupy a port on all interfaces (matching production behavior)
+	// #nosec G102 -- test intentionally binds to all interfaces to match production port checking
 	listener, err := net.Listen("tcp", ":0")
 	assert.NoError(t, err, "should create listener")
 	defer listener.Close()
@@ -231,11 +232,13 @@ func TestPortChecker_CheckAvailability_ExcludeMap(t *testing.T) {
 func TestPortChecker_CheckAvailability_MultipleSkipPorts(t *testing.T) {
 	pc := NewPortChecker()
 
-	// Create multiple listeners
+	// Create multiple listeners on all interfaces (matching production behavior)
+	// #nosec G102 -- test intentionally binds to all interfaces to match production port checking
 	listener1, err := net.Listen("tcp", ":0")
 	assert.NoError(t, err)
 	defer listener1.Close()
 
+	// #nosec G102 -- test intentionally binds to all interfaces to match production port checking
 	listener2, err := net.Listen("tcp", ":0")
 	assert.NoError(t, err)
 	defer listener2.Close()
@@ -353,7 +356,8 @@ func TestNewPortChecker(t *testing.T) {
 func TestPortChecker_PortAvailability_Integration(t *testing.T) {
 	pc := NewPortChecker()
 
-	// Create a listener to occupy a port
+	// Create a listener to occupy a port on all interfaces (matching production behavior)
+	// #nosec G102 -- test intentionally binds to all interfaces to match production port checking
 	listener, err := net.Listen("tcp", ":0")
 	assert.NoError(t, err, "should create listener")
 	defer listener.Close()

--- a/internal/forward/worker_unit_test.go
+++ b/internal/forward/worker_unit_test.go
@@ -55,8 +55,8 @@ func TestLogWriter_Write(t *testing.T) {
 func TestForwardWorker_GetForward(t *testing.T) {
 	tests := []struct {
 		name        string
-		forward     config.Forward
 		description string
+		forward     config.Forward
 	}{
 		{
 			name: "get pod forward",
@@ -141,9 +141,9 @@ func TestForwardWorker_IsRunning(t *testing.T) {
 func TestForwardID(t *testing.T) {
 	tests := []struct {
 		name         string
+		description  string
 		forward      config.Forward
 		expectUnique bool
-		description  string
 	}{
 		{
 			name: "unique IDs for different forwards",
@@ -183,9 +183,9 @@ func TestForwardID(t *testing.T) {
 func TestForwardString(t *testing.T) {
 	tests := []struct {
 		name             string
-		forward          config.Forward
-		expectedContains []string
 		description      string
+		expectedContains []string
+		forward          config.Forward
 	}{
 		{
 			name: "pod forward string",
@@ -259,8 +259,8 @@ func TestSleepWithBackoffConcept(t *testing.T) {
 func TestWorkerVerboseMode(t *testing.T) {
 	tests := []struct {
 		name        string
-		verbose     bool
 		description string
+		verbose     bool
 	}{
 		{
 			name:        "verbose mode enabled",

--- a/internal/healthcheck/checker_test.go
+++ b/internal/healthcheck/checker_test.go
@@ -88,9 +88,9 @@ func (s *HealthCheckTestSuite) TestRegisterAndUnregister() {
 func (s *HealthCheckTestSuite) TestTCPDialMethod() {
 	tests := []struct {
 		name           string
-		setupPort      bool
 		expectedStatus Status
 		description    string
+		setupPort      bool
 	}{
 		{
 			name:           "port available - healthy",
@@ -109,10 +109,9 @@ func (s *HealthCheckTestSuite) TestTCPDialMethod() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var testPort int
-			var testListener net.Listener
 
 			if tt.setupPort {
-				// Use the existing listener
+				// Use the existing listener from suite setup
 				testPort = s.port
 			} else {
 				// Use a port that's not listening
@@ -143,10 +142,6 @@ func (s *HealthCheckTestSuite) TestTCPDialMethod() {
 			status, exists := checker.GetStatus("test-forward")
 			assert.True(s.T(), exists)
 			assert.Equal(s.T(), tt.expectedStatus, status, tt.description)
-
-			if testListener != nil {
-				testListener.Close()
-			}
 		})
 	}
 }
@@ -201,7 +196,7 @@ func (s *HealthCheckTestSuite) TestDataTransferMethod() {
 						}
 						switch tt.serverBehavior {
 						case "banner":
-							conn.Write([]byte("220 Welcome\r\n"))
+							_, _ = conn.Write([]byte("220 Welcome\r\n"))
 							time.Sleep(50 * time.Millisecond)
 							conn.Close()
 						case "close":

--- a/internal/httplog/logger_test.go
+++ b/internal/httplog/logger_test.go
@@ -166,15 +166,15 @@ func TestLogger_Log_Error(t *testing.T) {
 func TestLogger_BodyTruncation(t *testing.T) {
 	tests := []struct {
 		name        string
-		maxBodyLen  int
 		body        string
+		maxBodyLen  int
 		expectTrunc bool
 	}{
-		{"body under limit", 100, "short", false},
-		{"body at limit", 5, "exact", false},
-		{"body over limit", 5, "this is too long", true},
-		{"empty body", 100, "", false},
-		{"zero max", 0, "any", true},
+		{name: "body under limit", maxBodyLen: 100, body: "short", expectTrunc: false},
+		{name: "body at limit", maxBodyLen: 5, body: "exact", expectTrunc: false},
+		{name: "body over limit", maxBodyLen: 5, body: "this is too long", expectTrunc: true},
+		{name: "empty body", maxBodyLen: 100, body: "", expectTrunc: false},
+		{name: "zero max", maxBodyLen: 0, body: "any", expectTrunc: true},
 	}
 
 	for _, tt := range tests {
@@ -186,10 +186,10 @@ func TestLogger_BodyTruncation(t *testing.T) {
 				output:     &buf,
 			}
 
-			l.Log(Entry{Body: tt.body})
+			_ = l.Log(Entry{Body: tt.body})
 
 			var entry Entry
-			json.Unmarshal(buf.Bytes(), &entry)
+			_ = json.Unmarshal(buf.Bytes(), &entry)
 
 			if tt.expectTrunc {
 				assert.Contains(t, entry.Body, "...(truncated)")
@@ -219,9 +219,9 @@ func TestLogger_Callbacks(t *testing.T) {
 	})
 
 	// Log entries
-	l.Log(Entry{Direction: "request", Path: "/api/1"})
-	l.Log(Entry{Direction: "response", Path: "/api/1"})
-	l.Log(Entry{Direction: "request", Path: "/api/2"})
+	_ = l.Log(Entry{Direction: "request", Path: "/api/1"})
+	_ = l.Log(Entry{Direction: "response", Path: "/api/1"})
+	_ = l.Log(Entry{Direction: "request", Path: "/api/2"})
 
 	mu.Lock()
 	assert.Len(t, received, 3)
@@ -244,7 +244,7 @@ func TestLogger_MultipleCallbacks(t *testing.T) {
 	l.AddCallback(func(entry Entry) { count1++ })
 	l.AddCallback(func(entry Entry) { count2++ })
 
-	l.Log(Entry{})
+	_ = l.Log(Entry{})
 
 	assert.Equal(t, 1, count1)
 	assert.Equal(t, 1, count2)
@@ -261,12 +261,12 @@ func TestLogger_ClearCallbacks(t *testing.T) {
 	count := 0
 	l.AddCallback(func(entry Entry) { count++ })
 
-	l.Log(Entry{})
+	_ = l.Log(Entry{})
 	assert.Equal(t, 1, count)
 
 	l.ClearCallbacks()
 
-	l.Log(Entry{})
+	_ = l.Log(Entry{})
 	assert.Equal(t, 1, count) // Still 1 - callback was cleared
 }
 
@@ -321,7 +321,7 @@ func TestLogger_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			l.Log(Entry{
+			_ = l.Log(Entry{
 				Direction: "request",
 				Path:      "/api/" + string(rune('a'+n%26)),
 			})

--- a/internal/httplog/proxy_test.go
+++ b/internal/httplog/proxy_test.go
@@ -331,7 +331,7 @@ func TestProxy_Start_PortInUse(t *testing.T) {
 	}
 	err := proxy1.Start()
 	require.NoError(t, err)
-	defer proxy1.Stop()
+	defer func() { _ = proxy1.Stop() }()
 
 	// Get the actual port
 	addr := proxy1.listener.Addr().(*net.TCPAddr)
@@ -353,9 +353,9 @@ func TestProxy_Start_PortInUse(t *testing.T) {
 // TestFlattenHeaders_EdgeCases tests header flattening edge cases
 func TestFlattenHeaders_EdgeCases(t *testing.T) {
 	tests := []struct {
-		name     string
 		headers  http.Header
 		expected map[string]string
+		name     string
 	}{
 		{
 			name:     "empty headers",

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -146,8 +146,8 @@ func TestClientPool_ThreadSafety(t *testing.T) {
 		go func() {
 			pool.ClearCache()
 			pool.RemoveContext("test-context")
-			pool.GetCurrentContext()
-			pool.ListContexts()
+			_, _ = pool.GetCurrentContext()
+			_, _ = pool.ListContexts()
 			done <- true
 		}()
 	}

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -28,11 +28,11 @@ func NewDiscovery(pool *ClientPool) *Discovery {
 
 // PodInfo contains information about a pod relevant for port forwarding.
 type PodInfo struct {
+	Created    metav1.Time
 	Name       string
 	Namespace  string
-	Containers []ContainerInfo
 	Status     string
-	Created    metav1.Time
+	Containers []ContainerInfo
 }
 
 // ContainerInfo contains information about a container within a pod.
@@ -44,17 +44,17 @@ type ContainerInfo struct {
 // PortInfo describes a port exposed by a container or service.
 type PortInfo struct {
 	Name       string
-	Port       int32
-	TargetPort int32 // For services: the actual pod port to forward to
 	Protocol   string
+	Port       int32
+	TargetPort int32
 }
 
 // ServiceInfo contains information about a service.
 type ServiceInfo struct {
 	Name      string
 	Namespace string
-	Ports     []PortInfo
 	Type      string
+	Ports     []PortInfo
 }
 
 // ListContexts returns all available Kubernetes contexts from kubeconfig.

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestResolveTargetPort(t *testing.T) {
 	tests := []struct {
-		name         string
-		servicePort  corev1.ServicePort
 		service      *corev1.Service
+		name         string
+		description  string
+		servicePort  corev1.ServicePort
 		pods         []corev1.Pod
 		expectedPort int32
-		description  string
 	}{
 		{
 			name: "numeric targetPort",

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -49,16 +49,16 @@ func (pf *PortForwarder) SetDialTimeout(timeout time.Duration) {
 
 // ForwardRequest contains the parameters for a port-forward request.
 type ForwardRequest struct {
-	ContextName string // Kubernetes context name
-	Namespace   string // Namespace
-	Resource    string // Resource (pod/name or service/name)
-	Selector    string // Label selector (for pod resolution)
-	LocalPort   int    // Local port
-	RemotePort  int    // Remote port
+	Out         io.Writer
+	ErrOut      io.Writer
 	StopChan    chan struct{}
 	ReadyChan   chan struct{}
-	Out         io.Writer // Output writer for logs
-	ErrOut      io.Writer // Error output writer
+	ContextName string
+	Namespace   string
+	Resource    string
+	Selector    string
+	LocalPort   int
+	RemotePort  int
 }
 
 // Forward establishes a port-forward connection to a Kubernetes resource.

--- a/internal/k8s/resolver.go
+++ b/internal/k8s/resolver.go
@@ -19,15 +19,15 @@ const (
 
 // ResolvedResource represents a resolved Kubernetes resource.
 type ResolvedResource struct {
-	Name      string    // The resolved pod or service name
-	Namespace string    // The namespace
-	Timestamp time.Time // When this was resolved
+	Timestamp time.Time
+	Name      string
+	Namespace string
 }
 
 // cacheEntry stores a cached resolution result with expiry.
 type cacheEntry struct {
-	resource  ResolvedResource
 	expiresAt time.Time
+	resource  ResolvedResource
 }
 
 // ResourceResolver resolves Kubernetes resources with caching.
@@ -188,7 +188,7 @@ func (r *ResourceResolver) getFromCache(key string) string {
 		// Upgrade to write lock and delete expired entry
 		r.cacheMu.Lock()
 		// Double-check entry still exists and is still expired (may have been updated)
-		if entry, exists := r.cache[key]; exists && time.Now().After(entry.expiresAt) {
+		if expiredEntry, ok := r.cache[key]; ok && time.Now().After(expiredEntry.expiresAt) {
 			delete(r.cache, key)
 		}
 		r.cacheMu.Unlock()

--- a/internal/logger/klog_bridge_test.go
+++ b/internal/logger/klog_bridge_test.go
@@ -17,10 +17,10 @@ func TestKlogWriter(t *testing.T) {
 		input         string
 		expectedLevel string
 		expectedMsg   string
+		description   string
 		loggerLevel   Level
 		loggerFormat  Format
 		shouldLog     bool
-		description   string
 	}{
 		{
 			name:          "info level log",
@@ -162,9 +162,9 @@ func TestKlogWriter(t *testing.T) {
 func TestKlogWriterBuffering(t *testing.T) {
 	tests := []struct {
 		name        string
+		description string
 		writes      []string
 		expectCount int
-		description string
 	}{
 		{
 			name: "single complete line",
@@ -264,7 +264,7 @@ func TestKlogWriterConcurrency(t *testing.T) {
 		go func(id int) {
 			for j := 0; j < numWrites; j++ {
 				msg := fmt.Sprintf("I1124 12:34:56.789012   12345 test.go:123] Message from goroutine %d iteration %d\n", id, j)
-				klogWriter.Write([]byte(msg))
+				_, _ = klogWriter.Write([]byte(msg))
 			}
 			done <- true
 		}(i)

--- a/internal/logger/klog_logr_test.go
+++ b/internal/logger/klog_logr_test.go
@@ -14,12 +14,12 @@ import (
 func TestLogrAdapter_Info(t *testing.T) {
 	tests := []struct {
 		name           string
-		loggerLevel    Level
-		logrLevel      int
 		message        string
 		keysAndValues  []interface{}
-		expectOutput   bool
 		expectContains []string
+		loggerLevel    Level
+		logrLevel      int
+		expectOutput   bool
 	}{
 		{
 			name:           "info log v0 with debug logger",
@@ -109,13 +109,13 @@ func TestLogrAdapter_Info(t *testing.T) {
 
 func TestLogrAdapter_Error(t *testing.T) {
 	tests := []struct {
-		name           string
-		loggerLevel    Level
 		err            error
+		name           string
 		message        string
 		keysAndValues  []interface{}
-		expectOutput   bool
 		expectContains []string
+		loggerLevel    Level
+		expectOutput   bool
 	}{
 		{
 			name:           "error with error object",
@@ -179,9 +179,9 @@ func TestLogrAdapter_Error(t *testing.T) {
 func TestLogrAdapter_WithName(t *testing.T) {
 	tests := []struct {
 		name           string
-		loggerNames    []string
 		message        string
 		expectContains string
+		loggerNames    []string
 	}{
 		{
 			name:           "single logger name",

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestLoggerTextFormat(t *testing.T) {
 	tests := []struct {
+		fields         map[string]interface{}
 		name           string
+		message        string
+		expectContains []string
 		level          Level
 		logLevel       Level
-		message        string
-		fields         map[string]interface{}
 		expectOutput   bool
-		expectContains []string
 	}{
 		{
 			name:           "info logged at info level",
@@ -138,13 +138,13 @@ func TestLoggerTextFormat(t *testing.T) {
 
 func TestLoggerJSONFormat(t *testing.T) {
 	tests := []struct {
+		fields       map[string]interface{}
 		name         string
+		message      string
+		expectLevel  string
 		level        Level
 		logLevel     Level
-		message      string
-		fields       map[string]interface{}
 		expectOutput bool
-		expectLevel  string
 	}{
 		{
 			name:         "info logged at info level",
@@ -268,12 +268,12 @@ func TestLoggerJSONFormat(t *testing.T) {
 
 func TestGlobalLogger(t *testing.T) {
 	tests := []struct {
-		name           string
-		initLevel      Level
-		initFormat     Format
 		logFunc        func(string, ...map[string]interface{})
+		name           string
 		message        string
 		expectContains string
+		initLevel      Level
+		initFormat     Format
 	}{
 		{
 			name:           "global info logger text",
@@ -321,9 +321,9 @@ func TestGlobalLogger(t *testing.T) {
 func TestLogLevelsFiltering(t *testing.T) {
 	tests := []struct {
 		name          string
-		loggerLevel   Level
 		logAtLevels   []Level
 		expectOutputs []bool
+		loggerLevel   Level
 	}{
 		{
 			name:          "debug level logs everything",
@@ -387,14 +387,14 @@ func TestLoggerNilOutput(t *testing.T) {
 
 func TestLevelToString(t *testing.T) {
 	tests := []struct {
-		level    Level
 		expected string
+		level    Level
 	}{
-		{LevelDebug, "DEBUG"},
-		{LevelInfo, "INFO"},
-		{LevelWarn, "WARN"},
-		{LevelError, "ERROR"},
-		{Level(999), "UNKNOWN"},
+		{level: LevelDebug, expected: "DEBUG"},
+		{level: LevelInfo, expected: "INFO"},
+		{level: LevelWarn, expected: "WARN"},
+		{level: LevelError, expected: "ERROR"},
+		{level: Level(999), expected: "UNKNOWN"},
 	}
 
 	for _, tt := range tests {
@@ -407,8 +407,8 @@ func TestLevelToString(t *testing.T) {
 
 func TestJSONFieldTypes(t *testing.T) {
 	tests := []struct {
-		name   string
 		fields map[string]interface{}
+		name   string
 	}{
 		{
 			name: "string fields",
@@ -467,10 +467,10 @@ func TestJSONFieldTypes(t *testing.T) {
 
 func TestInitWithCustomOutput(t *testing.T) {
 	tests := []struct {
-		name          string
 		output        io.Writer
-		expectDiscard bool
+		name          string
 		description   string
+		expectDiscard bool
 	}{
 		{
 			name:          "init with custom buffer",

--- a/internal/mdns/publisher.go
+++ b/internal/mdns/publisher.go
@@ -1,3 +1,16 @@
+// Package mdns provides multicast DNS (mDNS/Bonjour) hostname publishing
+// for port forwards. When enabled, forwards with aliases can be accessed
+// via <alias>.local hostnames on the local network.
+//
+// The Publisher manages mDNS service registrations using zeroconf:
+//   - Registers hostnames when forwards become active
+//   - Unregisters hostnames when forwards are stopped
+//   - Provides service discovery via the _kportal._tcp service type
+//
+// mDNS discovery commands:
+//
+//	dns-sd -B _kportal._tcp local    # macOS
+//	avahi-browse -t _kportal._tcp    # Linux
 package mdns
 
 import (
@@ -23,11 +36,11 @@ const (
 // Publisher manages mDNS hostname registrations for port forwards.
 // It allows forwards with aliases to be accessible via <alias>.local hostnames.
 type Publisher struct {
-	mu       sync.RWMutex
-	servers  map[string]*zeroconf.Server // forwardID -> server
-	aliases  map[string]string           // forwardID -> alias (for logging)
-	enabled  bool
+	servers  map[string]*zeroconf.Server
+	aliases  map[string]string
 	localIPs []string
+	mu       sync.RWMutex
+	enabled  bool
 }
 
 // NewPublisher creates a new mDNS Publisher.

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -1,3 +1,19 @@
+// Package retry provides exponential backoff with jitter for retry logic.
+// It implements a backoff sequence of 1s → 2s → 4s → 8s → 10s (max),
+// with 10% random jitter to prevent thundering herd problems.
+//
+// Basic usage:
+//
+//	backoff := retry.NewBackoff()
+//	for {
+//	    err := doSomething()
+//	    if err == nil {
+//	        backoff.Reset()
+//	        break
+//	    }
+//	    delay := backoff.Next()
+//	    time.Sleep(delay)
+//	}
 package retry
 
 import (
@@ -19,8 +35,8 @@ const (
 // Backoff implements exponential backoff with jitter for retry logic.
 // The backoff sequence is: 1s → 2s → 4s → 8s → 10s (max, then stays at 10s).
 type Backoff struct {
-	attempt int
 	rng     *rand.Rand
+	attempt int
 }
 
 // NewBackoff creates a new Backoff instance with a seeded random number generator.
@@ -53,7 +69,7 @@ func (b *Backoff) Next() time.Duration {
 
 	// Add jitter (±10%)
 	jitter := b.calculateJitter(delay)
-	delay = delay + jitter
+	delay += jitter
 
 	b.attempt++
 	return delay

--- a/internal/ui/commands_test.go
+++ b/internal/ui/commands_test.go
@@ -82,13 +82,16 @@ func TestMessageTypes(t *testing.T) {
 		}
 		assert.Equal(t, 8080, availableMsg.port)
 		assert.True(t, availableMsg.available)
+		assert.Equal(t, "Port 8080 available", availableMsg.message)
 
 		unavailableMsg := PortCheckedMsg{
 			port:      8080,
 			available: false,
 			message:   "Port 8080 in use by process",
 		}
+		assert.Equal(t, 8080, unavailableMsg.port)
 		assert.False(t, unavailableMsg.available)
+		assert.Equal(t, "Port 8080 in use by process", unavailableMsg.message)
 	})
 
 	t.Run("ForwardSavedMsg", func(t *testing.T) {
@@ -117,10 +120,10 @@ func TestMessageTypes(t *testing.T) {
 	t.Run("BenchmarkCompleteMsg", func(t *testing.T) {
 		msg := BenchmarkCompleteMsg{
 			ForwardID: "fwd-123",
-			Results:   nil,
-			Error:     nil,
 		}
 		assert.Equal(t, "fwd-123", msg.ForwardID)
+		assert.Nil(t, msg.Results)
+		assert.Nil(t, msg.Error)
 	})
 
 	t.Run("BenchmarkProgressMsg", func(t *testing.T) {
@@ -256,7 +259,7 @@ func TestRunBenchmarkCmd_Cancellation(t *testing.T) {
 
 	// Run with timeout to prevent hanging
 	done := make(chan bool, 1)
-	var msg interface{}
+	var msg any
 	go func() {
 		msg = cmd()
 		done <- true

--- a/internal/ui/constants.go
+++ b/internal/ui/constants.go
@@ -1,0 +1,45 @@
+package ui
+
+// Terminal dimension constants
+const (
+	// DefaultTermWidth is the fallback terminal width when not detected
+	DefaultTermWidth = 120
+
+	// DefaultTermHeight is the fallback terminal height when not detected
+	DefaultTermHeight = 40
+)
+
+// Table column constants
+const (
+	// Column indices in the forwards table
+	ColumnContext   = 0
+	ColumnNamespace = 1
+	ColumnAlias     = 2
+	ColumnType      = 3
+	ColumnResource  = 4
+	ColumnRemote    = 5
+	ColumnLocal     = 6
+	ColumnStatus    = 7
+
+	// Column widths for truncation
+	ColumnWidthContext   = 14
+	ColumnWidthNamespace = 16
+	ColumnWidthAlias     = 18
+	ColumnWidthType      = 8
+	ColumnWidthResource  = 20
+
+	// Error display widths
+	ErrorDisplayWidth = 118 // Slightly less than table width (120) for padding
+)
+
+// Viewport constants
+const (
+	// ViewportHeight is the number of items visible in list views
+	ViewportHeight = 20
+)
+
+// Path display constants
+const (
+	// MaxPathWidth is the maximum width for displaying file paths
+	MaxPathWidth = 48
+)

--- a/internal/ui/handlers_test.go
+++ b/internal/ui/handlers_test.go
@@ -695,12 +695,12 @@ func TestHandleSelectorValidated(t *testing.T) {
 func TestHandlePortChecked(t *testing.T) {
 	tests := []struct {
 		name        string
-		available   bool
 		expectStep  AddWizardStep
+		available   bool
 		expectError bool
 	}{
-		{"port available", true, StepConfirmation, false},
-		{"port in use", false, StepEnterLocalPort, true},
+		{name: "port available", available: true, expectStep: StepConfirmation, expectError: false},
+		{name: "port in use", available: false, expectStep: StepEnterLocalPort, expectError: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/httplog_state_test.go
+++ b/internal/ui/httplog_state_test.go
@@ -180,13 +180,13 @@ func TestHTTPLogState_GetFilterModeLabel(t *testing.T) {
 	state := newHTTPLogState("fwd", "alias")
 
 	tests := []struct {
-		mode     HTTPLogFilterMode
 		expected string
+		mode     HTTPLogFilterMode
 	}{
-		{HTTPLogFilterNone, "All"},
-		{HTTPLogFilterText, "Text"},
-		{HTTPLogFilterNon200, "Non-2xx"},
-		{HTTPLogFilterErrors, "Errors (4xx/5xx)"},
+		{mode: HTTPLogFilterNone, expected: "All"},
+		{mode: HTTPLogFilterText, expected: "Text"},
+		{mode: HTTPLogFilterNon200, expected: "Non-2xx"},
+		{mode: HTTPLogFilterErrors, expected: "Errors (4xx/5xx)"},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/mocks_test.go
+++ b/internal/ui/mocks_test.go
@@ -10,36 +10,28 @@ import (
 
 // MockDiscovery is a mock implementation of DiscoveryInterface for testing
 type MockDiscovery struct {
-	mu sync.Mutex
-
-	// Return values
-	Contexts         []string
-	CurrentContext   string
-	Namespaces       []string
-	Pods             []k8s.PodInfo
-	PodsWithSelector []k8s.PodInfo
-	Services         []k8s.ServiceInfo
-
-	// Errors to return
-	ListContextsErr         error
-	GetCurrentContextErr    error
-	ListNamespacesErr       error
-	ListPodsErr             error
-	ListPodsWithSelectorErr error
-	ListServicesErr         error
-
-	// Call tracking
+	ListPodsErr               error
+	ListServicesErr           error
+	ListPodsWithSelectorErr   error
+	ListContextsErr           error
+	GetCurrentContextErr      error
+	ListNamespacesErr         error
+	LastSelector              string
+	CurrentContext            string
+	LastNamespace             string
+	LastContextName           string
+	PodsWithSelector          []k8s.PodInfo
+	Services                  []k8s.ServiceInfo
+	Pods                      []k8s.PodInfo
+	Namespaces                []string
+	Contexts                  []string
 	ListContextsCalls         int
 	GetCurrentContextCalls    int
 	ListNamespacesCalls       int
 	ListPodsCalls             int
 	ListPodsWithSelectorCalls int
 	ListServicesCalls         int
-
-	// Captured arguments
-	LastContextName string
-	LastNamespace   string
-	LastSelector    string
+	mu                        sync.Mutex
 }
 
 func NewMockDiscovery() *MockDiscovery {
@@ -104,34 +96,26 @@ func (m *MockDiscovery) ListServices(ctx context.Context, contextName, namespace
 
 // MockMutator is a mock implementation of MutatorInterface for testing
 type MockMutator struct {
-	mu sync.Mutex
-
-	// Errors to return
-	AddForwardErr        error
-	RemoveForwardsErr    error
 	RemoveForwardByIDErr error
 	UpdateForwardErr     error
-
-	// Call tracking
-	AddForwardCalls        int
-	RemoveForwardsCalls    int
-	RemoveForwardByIDCalls int
-	UpdateForwardCalls     int
-
-	// Captured arguments
-	LastContextName   string
-	LastNamespaceName string
-	LastForward       config.Forward
-	LastOldID         string
-	LastRemovedID     string
-	LastPredicate     func(ctx, ns string, fwd config.Forward) bool
-
-	// Storage for testing
-	Forwards []struct {
+	AddForwardErr        error
+	RemoveForwardsErr    error
+	LastPredicate        func(ctx, ns string, fwd config.Forward) bool
+	LastContextName      string
+	LastOldID            string
+	LastNamespaceName    string
+	LastRemovedID        string
+	Forwards             []struct {
 		Context   string
 		Namespace string
 		Forward   config.Forward
 	}
+	LastForward            config.Forward
+	RemoveForwardByIDCalls int
+	UpdateForwardCalls     int
+	RemoveForwardsCalls    int
+	AddForwardCalls        int
+	mu                     sync.Mutex
 }
 
 func NewMockMutator() *MockMutator {
@@ -186,14 +170,10 @@ func (m *MockMutator) UpdateForward(oldID, newContextName, newNamespaceName stri
 
 // MockHTTPLogSubscriber is a mock for HTTP log subscription
 type MockHTTPLogSubscriber struct {
-	mu sync.Mutex
-
-	// Subscription tracking
 	Subscriptions map[string]func(HTTPLogEntry)
 	CleanupCalls  int
-
-	// Control
-	ShouldFail bool
+	mu            sync.Mutex
+	ShouldFail    bool
 }
 
 func NewMockHTTPLogSubscriber() *MockHTTPLogSubscriber {
@@ -237,11 +217,11 @@ func (m *MockHTTPLogSubscriber) GetSubscriberFunc() HTTPLogSubscriber {
 
 // MockToggleCallback tracks toggle callback invocations
 type MockToggleCallback struct {
-	mu    sync.Mutex
 	Calls []struct {
 		ID     string
 		Enable bool
 	}
+	mu sync.Mutex
 }
 
 func NewMockToggleCallback() *MockToggleCallback {

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -14,17 +14,17 @@ type ForwardStatus struct {
 	Context    string
 	Namespace  string
 	Alias      string
-	Type       string // "service", "pod", etc.
-	Resource   string // name without type prefix
+	Type       string
+	Resource   string
+	Status     string
 	RemotePort int
 	LocalPort  int
-	Status     string // "Starting", "Active", "Reconnecting", "Error"
 }
 
 // TableUI manages the terminal table display
 type TableUI struct {
+	forwards map[string]*ForwardStatus
 	mu       sync.RWMutex
-	forwards map[string]*ForwardStatus // key is forward ID
 	verbose  bool
 }
 
@@ -101,12 +101,12 @@ func (t *TableUI) Render() {
 
 	// Sort forwards by local port for consistent display
 	type sortEntry struct {
-		id  string
 		fwd *ForwardStatus
+		id  string
 	}
 	var entries []sortEntry
 	for id, fwd := range t.forwards {
-		entries = append(entries, sortEntry{id, fwd})
+		entries = append(entries, sortEntry{fwd: fwd, id: id})
 	}
 
 	// Simple sort by local port

--- a/internal/ui/wizard_commands.go
+++ b/internal/ui/wizard_commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nvm/kportal/internal/benchmark"
 	"github.com/nvm/kportal/internal/config"
 	"github.com/nvm/kportal/internal/k8s"
+	"github.com/nvm/kportal/internal/logger"
 )
 
 const (
@@ -19,53 +20,53 @@ const (
 
 // ContextsLoadedMsg is sent when contexts have been loaded
 type ContextsLoadedMsg struct {
-	contexts []string
 	err      error
+	contexts []string
 }
 
 // NamespacesLoadedMsg is sent when namespaces have been loaded
 type NamespacesLoadedMsg struct {
-	namespaces []string
 	err        error
+	namespaces []string
 }
 
 // PodsLoadedMsg is sent when pods have been loaded
 type PodsLoadedMsg struct {
-	pods []k8s.PodInfo
 	err  error
+	pods []k8s.PodInfo
 }
 
 // ServicesLoadedMsg is sent when services have been loaded
 type ServicesLoadedMsg struct {
-	services []k8s.ServiceInfo
 	err      error
+	services []k8s.ServiceInfo
 }
 
 // SelectorValidatedMsg is sent when a selector has been validated
 type SelectorValidatedMsg struct {
-	valid bool
-	pods  []k8s.PodInfo
 	err   error
+	pods  []k8s.PodInfo
+	valid bool
 }
 
 // PortCheckedMsg is sent when a port's availability has been checked
 type PortCheckedMsg struct {
+	message   string
 	port      int
 	available bool
-	message   string
 }
 
 // ForwardSavedMsg is sent when a forward has been saved to config
 type ForwardSavedMsg struct {
-	success bool
 	err     error
+	success bool
 }
 
 // ForwardsRemovedMsg is sent when forwards have been removed from config
 type ForwardsRemovedMsg struct {
-	success bool
-	count   int
 	err     error
+	count   int
+	success bool
 }
 
 // WizardCompleteMsg signals that the wizard has completed
@@ -241,9 +242,9 @@ func removeForwardByIDCmd(mutator *config.Mutator, id string) tea.Cmd {
 
 // BenchmarkCompleteMsg is sent when a benchmark run completes
 type BenchmarkCompleteMsg struct {
-	ForwardID string
-	Results   *benchmark.Results
 	Error     error
+	Results   *benchmark.Results
+	ForwardID string
 }
 
 // BenchmarkProgressMsg is sent periodically during benchmark execution
@@ -291,7 +292,7 @@ func runBenchmarkCmd(ctx context.Context, forwardID string, localPort int, urlPa
 				// Recover from panics in the callback
 				defer func() {
 					if r := recover(); r != nil {
-						// Silently recover - progress callback failure shouldn't crash the benchmark
+						logger.Debug("recovered from panic in progress callback", map[string]any{"panic": r})
 					}
 				}()
 				// Non-blocking send to progress channel

--- a/internal/ui/wizard_exclusion_test.go
+++ b/internal/ui/wizard_exclusion_test.go
@@ -86,10 +86,10 @@ func TestWizardMutualExclusion_HTTPLogBlocksOthers(t *testing.T) {
 // TestWizardMutualExclusion_CheckActiveModal tests the modal activity check logic
 func TestWizardMutualExclusion_CheckActiveModal(t *testing.T) {
 	tests := []struct {
-		name           string
 		setupFunc      func(*BubbleTeaUI)
-		expectActive   bool
+		name           string
 		activeModalStr string
+		expectActive   bool
 	}{
 		{
 			name:           "no modal active",

--- a/internal/ui/wizard_state_test.go
+++ b/internal/ui/wizard_state_test.go
@@ -285,10 +285,10 @@ func TestClearSearchFilter(t *testing.T) {
 func TestMoveCursorWithFilteredLists(t *testing.T) {
 	tests := []struct {
 		name           string
-		step           AddWizardStep
+		searchFilter   string
 		contexts       []string
 		namespaces     []string
-		searchFilter   string
+		step           AddWizardStep
 		initialCursor  int
 		delta          int
 		expectedCursor int

--- a/internal/ui/wizard_styles.go
+++ b/internal/ui/wizard_styles.go
@@ -143,7 +143,6 @@ func renderBreadcrumb(parts ...string) string {
 func renderList(items []string, cursor int, prefix string, scrollOffset int) string {
 	var b strings.Builder
 
-	const viewportHeight = 20
 	totalItems := len(items)
 
 	// Show scroll up indicator if there are items above the viewport
@@ -153,7 +152,7 @@ func renderList(items []string, cursor int, prefix string, scrollOffset int) str
 
 	// Calculate visible range
 	start := scrollOffset
-	end := scrollOffset + viewportHeight
+	end := scrollOffset + ViewportHeight
 	if end > totalItems {
 		end = totalItems
 	}

--- a/internal/version/checker.go
+++ b/internal/version/checker.go
@@ -1,3 +1,15 @@
+// Package version provides version checking against GitHub releases.
+// It queries the GitHub API to check for newer versions of kportal
+// and provides update notifications.
+//
+// Basic usage:
+//
+//	info, err := version.CheckForUpdate(ctx, "owner", "repo", "v1.0.0")
+//	if err != nil {
+//	    log.Printf("Version check failed: %v", err)
+//	} else if info.UpdateAvailable {
+//	    fmt.Printf("Update available: %s -> %s\n", info.CurrentVersion, info.LatestVersion)
+//	}
 package version
 
 import (
@@ -33,10 +45,10 @@ type UpdateInfo struct {
 
 // Checker checks for new versions on GitHub
 type Checker struct {
+	client  *http.Client
 	owner   string
 	repo    string
 	current string
-	client  *http.Client
 }
 
 // NewChecker creates a new version checker


### PR DESCRIPTION
- [x] Add golangci-lint configuration with gocritic ifElseChain disabled
- [x] Rename error variables to avoid shadowing (createErr, watcherErr, watchErr, etc.)
- [x] Replace `interface{}` with `any` type alias throughout codebase
- [x] Add package-level documentation comments to all internal packages
- [x] Reorder struct fields alphabetically for consistency
- [x] Extract UI constants (terminal dimensions, column widths, colors) to constants.go
- [x] Refactor BubbleTeaUI main view rendering into smaller helper functions
- [x] Simplify nested conditionals and improve code clarity
- [x] Add `isForwardDisabled()` helper method to BubbleTeaUI
- [x] Update file permissions from 0644 to 0600 in config tests
- [x] Add `#nosec` comments and error suppression where appropriate
- [x] Improve test table struct field ordering for readability
- [x] Fix resource parsing in AddForward using strings.SplitN
- [x] Add comprehensive tests for new UI helper functions and constants
